### PR TITLE
Removes Google PageSpeed Cache suggestion.

### DIFF
--- a/views/caching.htm
+++ b/views/caching.htm
@@ -37,6 +37,7 @@
     # Webfonts
     ExpiresByType font/truetype "access plus 1 year"
     ExpiresByType font/opentype "access plus 1 year"
+    ExpiresByType font/woff2 "access plus 1 year"
     ExpiresByType application/x-font-woff "access plus 1 year"
     ExpiresByType image/svg+xml "access plus 1 year"
     ExpiresByType application/vnd.ms-fontobject "access plus 1 year"


### PR DESCRIPTION
Since I load all fonts from the same server I've been getting this Google PageSeed suggestion about the expiry dates on woff2 files. Adding just the font/woff2 type seems to fix them.