### PR TITLE
Add console commands to enable http2, gzip and caching

### DIFF
--- a/Plugin.php
+++ b/Plugin.php
@@ -26,6 +26,13 @@ class Plugin extends PluginBase
         ];
     }
 
+    public function register()
+    {
+        $this->registerConsoleCommand('speedy:enable-caching', \Offline\Speedy\Console\EnableCachingCommand::class);
+        $this->registerConsoleCommand('speedy:enable-gzip', \Offline\Speedy\Console\EnableGzipCommand::class);
+        $this->registerConsoleCommand('speedy:enable-http2', \Offline\Speedy\Console\EnableHttp2Command::class);
+    }
+
     public function boot()
     {
         $this->app[Kernel::class]->pushMiddleware(Http2Middleware::class);

--- a/README.md
+++ b/README.md
@@ -16,6 +16,28 @@ Speedy currently only works with the Apache web server with enabled `htaccess` f
 
 Speedy makes use of `mod_expires`, `mod_gzip` and `mod_headers`.
 
+##  Console commands
+
+There are a number of console commands to enable optimizations.
+
+**Enable HTTP/2 preloading:**
+
+```bash
+php artisan speedy:enable-http2
+```
+
+**Enable Gzip:**
+
+```bash
+php artisan speedy:enable-gzip
+```
+
+**Enable Caching:**
+
+```bash
+php artisan speedy:enable-caching
+```
+
 ## Attributions
 
 The speedy flash icon was created by [SagarUnagar](https://www.iconfinder.com/SagarUnagar) and is licensed under [CC BY 3.0](https://creativecommons.org/licenses/by/3.0/). Speedy uses a modified version of [JacobBennett's laravel-HTTP2ServerPush](https://github.com/JacobBennett/laravel-HTTP2ServerPush) middleware which is licensed under the [MIT license](https://github.com/JacobBennett/laravel-HTTP2ServerPush/blob/master/LICENSE.md).

--- a/console/EnableCachingCommand.php
+++ b/console/EnableCachingCommand.php
@@ -1,0 +1,27 @@
+<?php namespace Offline\Speedy\Console;
+
+use Illuminate\Console\Command;
+use OFFLINE\Speedy\Models\Settings as SpeedySettings;
+
+/**
+ * EnableCachingCommand
+ */
+class EnableCachingCommand extends Command
+{
+    protected $name = 'speedy:enable-caching';
+
+    protected $description = 'Enable Caching';
+
+    public function handle()
+    {
+        if (SpeedySettings::get('enable_caching')) {
+            $this->info('Caching is already enabled.');
+
+            return;
+        }
+
+        SpeedySettings::set(['enable_caching' => true]);
+
+        $this->output->success('Caching is now enabled.');
+    }
+}

--- a/console/EnableGzipCommand.php
+++ b/console/EnableGzipCommand.php
@@ -1,0 +1,27 @@
+<?php namespace Offline\Speedy\Console;
+
+use Illuminate\Console\Command;
+use OFFLINE\Speedy\Models\Settings as SpeedySettings;
+
+/**
+ * EnableGzipCommand
+ */
+class EnableGzipCommand extends Command
+{
+    protected $name = 'speedy:enable-gzip';
+
+    protected $description = 'Enable Gzip';
+
+    public function handle()
+    {
+        if (SpeedySettings::get('enable_gzip')) {
+            $this->info('Gzip is already enabled.');
+
+            return;
+        }
+
+        SpeedySettings::set(['enable_gzip' => true]);
+
+        $this->output->success('Gzip is now enabled.');
+    }
+}

--- a/console/EnableHttp2Command.php
+++ b/console/EnableHttp2Command.php
@@ -1,0 +1,27 @@
+<?php namespace Offline\Speedy\Console;
+
+use Illuminate\Console\Command;
+use OFFLINE\Speedy\Models\Settings as SpeedySettings;
+
+/**
+ * EnableHttp2Command
+ */
+class EnableHttp2Command extends Command
+{
+    protected $name = 'speedy:enable-http2';
+
+    protected $description = 'Enable HTTP/2 preloading';
+
+    public function handle()
+    {
+        if (SpeedySettings::get('http2_enabled')) {
+            $this->info('HTTP/2 is already enabled.');
+
+            return;
+        }
+
+        SpeedySettings::set(['http2_enabled' => true]);
+
+        $this->output->success('HTTP/2 preloading is now enabled.');
+    }
+}


### PR DESCRIPTION
This can be useful for deployment pipelines where these settings need to be toggled during every deployment because they write to the .htaccess file.